### PR TITLE
chore: update peerDep range for Zustand v4

### DIFF
--- a/packages/zutron/package.json
+++ b/packages/zutron/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "electron": ">=12",
-    "zustand": ">=5.0.0"
+    "zustand": ">=4.0.0"
   },
   "peerDependenciesMeta": {
     "electron": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,7 @@ importers:
         specifier: '>=12'
         version: 32.1.2
       zustand:
-        specifier: '>=5.0.0'
+        specifier: '>=4.0.0'
         version: 5.0.1(@types/react@18.3.12)(react@18.3.1)(use-sync-external-store@1.2.2(react@18.3.1))
     devDependencies:
       '@testing-library/jest-dom':


### PR DESCRIPTION
Zutron works with v4.x of Zustand, the peerDeps don't reflect this.